### PR TITLE
Fixed Bug about the msg lenght more than 512 can't output right HmacSHA1

### DIFF
--- a/hmac-sha1.c
+++ b/hmac-sha1.c
@@ -60,7 +60,8 @@ int sha1_finish (bitstr * msg, hsh * h) {
   p = *msg;
   while (p.l[1] || (p.l[0] >= 512)) {
     sha1_nxt (p.d, 512, h);     /* FIXME check return value? */
-    p.d += 512;
+    p.d += 64;
+    p.l[0] -= 512;
     if (p.l[0] < 512) {
       if (p.l[1]) {
         p.l[1]--;
@@ -68,7 +69,6 @@ int sha1_finish (bitstr * msg, hsh * h) {
       else
         return 1;               /* length underflow; FIXME redundant? */
     }
-    p.l[0] -= 512;
   }
   sha1_end (p.d, p.l[0], h);    /* FIXME check return value? */
   return 0;

--- a/hmac-sha1.c
+++ b/hmac-sha1.c
@@ -61,7 +61,6 @@ int sha1_finish (bitstr * msg, hsh * h) {
   while (p.l[1] || (p.l[0] >= 512)) {
     sha1_nxt (p.d, 512, h);     /* FIXME check return value? */
     p.d += 64;
-    p.l[0] -= 512;
     if (p.l[0] < 512) {
       if (p.l[1]) {
         p.l[1]--;
@@ -69,6 +68,7 @@ int sha1_finish (bitstr * msg, hsh * h) {
       else
         return 1;               /* length underflow; FIXME redundant? */
     }
+    p.l[0] -= 512;
   }
   sha1_end (p.d, p.l[0], h);    /* FIXME check return value? */
   return 0;


### PR DESCRIPTION
I run the program in Windows and use GCC 4.9.2